### PR TITLE
add ability to process requests via Julia function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ FastCGI is a binary protocol for interfacing interactive programs with a web ser
 
 FastCGI Specification: <http://www.mit.edu/~yandros/doc/specs/fcgi-spec.html>
 
-FastCGI.jl is a package that implements a Julia FastCGI client and server.
+FastCGI.jl is a package that implements a Julia FastCGI client and server. Additionally, it allows Julia functions to be used to respond directly to requests, which can be significantly faster and more efficient.
 
 ## Examples:
 
-### Using the server:
+### Using the server
+
 ```
 julia> using FastCGI
 
@@ -26,7 +27,8 @@ julia> process(server)
 ...
 ```
 
-### Using the client:
+### Using the client
+
 ```
 julia> using FastCGI
 
@@ -44,3 +46,29 @@ julia> wait(request.isdone)
 
 julia> response = String(take!(request.out));
 ```
+
+### Hooking up Julia functions
+
+FastCGI.jl server allows you to hook up a Julia function as a responder, instead of having to spawn an external process. This is much more efficient and fast. This can be an easy way to hook up a Julia backend to existing web servers like [Nginx](https://www.nginx.com/), [Apache](https://httpd.apache.org/) or [others](https://en.wikipedia.org/wiki/FastCGI#Web_servers_that_implement_FastCGI).
+
+To enable this mode, switch the runner to `FastCGI.FunctionRunner`:
+
+```
+FastCGI.set_server_runner(FastCGI.FunctionRunner)
+```
+
+Define the method that would respond to requests:
+
+```
+function fastcgi_responder(params, in, out, err)
+    # params: a Dict{String,String} with all fastcgi request parameters
+    # in: input stream to be read from
+    # out: output stream to write response to
+    # err: error stream to write errors to
+
+    # return the exit code that needs to be sent as the response
+    return 0
+end
+```
+
+Send requests as usual, ensuring that the `SCRIPT_FILENAME` parameter in requests contains the fully qualified function name to invoke.

--- a/src/FastCGI.jl
+++ b/src/FastCGI.jl
@@ -7,7 +7,8 @@ export FCGIServer, FCGIClient, FCGIRequest, process, isrunning, stop, set_server
 
 include("bufferedoutput.jl")
 include("types.jl")
-include("processhandler.jl")
+include("runners.jl")
+include("requesthandler.jl")
 include("server.jl")
 include("client.jl")
 

--- a/src/runners.jl
+++ b/src/runners.jl
@@ -1,0 +1,128 @@
+abstract type Runner end
+
+"""
+Holds all the plumbing required for a running process or function
+"""
+struct Plumbing
+    inp::Pipe                               # stdin
+    out::Pipe                               # stdout
+    err::Pipe                               # stderr
+
+    function Plumbing()
+        new(Pipe(), Pipe(), Pipe())
+    end
+end
+
+function close(plumbing::Plumbing; inputendsonly::Bool=false)
+    if inputendsonly
+        close(plumbing.out.in)
+        close(plumbing.err.in)
+    else
+        close(plumbing.inp)
+        close(plumbing.out)
+        close(plumbing.err)
+    end
+    nothing
+end
+
+function link(plumbing::Plumbing)
+    Base.link_pipe!(plumbing.inp)
+    Base.link_pipe!(plumbing.out)
+    Base.link_pipe!(plumbing.err)
+    nothing
+end
+
+"""
+Runs fast CGI commands as processes. Holds the runner process and allows waiting and terminating the process.
+"""
+mutable struct ProcessRunner <: Runner
+    process::Union{Base.Process,Nothing}    # launched process
+
+    function ProcessRunner()
+        new(nothing)
+    end
+end
+
+function killproc(runner::ProcessRunner)
+    if runner.process !== nothing
+        kill(runner.process)
+        runner.process = nothing
+    end
+    nothing
+end
+
+function waitproc(runner::ProcessRunner)
+    wait(runner.process)
+    runner.process.exitcode
+end
+
+function launchproc(runner::ProcessRunner, plumbing::Plumbing, params::Dict{String,String})
+    cmdpath = getcommand(params)
+    @debug("launching command", cmdpath)
+    if !isfile(cmdpath)
+        err = "cmdpath not found: $cmdpath"
+        @warn(err)
+        return 404, err
+    end
+    try
+        cmd = Cmd(`$cmdpath`; env=params)
+        runner.process = run(pipeline(cmd, stdin=plumbing.inp, stdout=plumbing.out, stderr=plumbing.err), wait=false)
+        return 0, ""
+    catch ex
+        @warn("process exception", cmdpath, params, ex)
+        return 500, "process exception"
+    end
+end
+
+"""
+Runs fast CGI commands as Julia functions. Holds the runner task and allows waiting and terminating (interrupting) the task.
+"""
+mutable struct FunctionRunner <: Runner
+    process::Union{Task,Nothing}
+
+    function FunctionRunner()
+        new(nothing)
+    end
+end
+
+function killproc(runner::FunctionRunner)
+    if (runner.process !== nothing) && !istaskdone(runner.process)
+        try
+            Base.throwto(runner.process, InterruptException())
+        catch ex
+            # ignore
+        end
+    end
+    runner.process = nothing
+    nothing
+end
+
+function waitproc(runner::FunctionRunner)
+    wait(runner.process)
+    Int(fetch(runner.process))
+end
+
+function launchproc(runner::FunctionRunner, plumbing::Plumbing, params::Dict{String,String})
+    cmdpath = getcommand(params)
+    @debug("launching command", cmdpath)
+
+    cmd = try
+        T = Main
+        for t in split(cmdpath, ".")
+            T = Base.eval(T, Symbol(t))
+        end
+        T::Function
+    catch ex
+        err = "Can not resolve $cmdpath"
+        @warn(err, ex)
+        return 404, err
+    end
+    try
+        link(plumbing)
+        runner.process = @async cmd(params, Base.pipe_reader(plumbing.inp), Base.pipe_writer(plumbing.out), Base.pipe_writer(plumbing.err))
+        return 0, ""
+    catch ex
+        @warn("process exception", cmdpath, params, ex)
+        return 500, "process exception"
+    end
+end

--- a/src/server.jl
+++ b/src/server.jl
@@ -5,11 +5,23 @@ const SERVER_PARAMS = Dict{String,String}(
     "FCGI_MPXS_CONNS"   =>  "1"
 )
 
+"""
+Set server parameters this server should respond with.
+Set values according to resources available on your system and the amount of load you wish this instance to take up.
+"""
 function set_server_param(name::String, value::String)
     SERVER_PARAMS[name] = value
     nothing
 end
 
+"""
+The runner type to use. Set this with the `set_server_runner` method.
+"""
+FCGI_RUNNER = ProcessRunner
+
+"""
+Set the runner type to use: `FastCGI.ProcessRunner` or `FastCGI.FunctionRunner`.
+"""
 function set_server_runner(runnertype)
     @assert supertype(runnertype) === Runner
     global FCGI_RUNNER


### PR DESCRIPTION
Add a new type of `Runner` - `FastCGI.FunctionRunner` that can respond to a FastCGI request through a plain Julia function instead of launching a new process. This is substantially more efficient.

The default runner is still the conventional `FastCGI.ProcessRunner`, but it can be switched. E.g.: `set_server_runner(FastCGI.FunctionRunner)`

Function name to execute needs to be provided via the FCGI parameter "SCRIPT_FILENAME". FastCGI would use `eval` to resolve the function. The function must have the following signature:

```
function fastcgi_responder(params, in, out, err)
    # params: a Dict{String,String} with all fastcgi request parameters
    # in: input stream to be read from
    # out: output stream to write response to
    # err: error stream to write errors to

    # return the exit code that needs to be sent as the response
    return 0
end
```